### PR TITLE
Fixed url to point to vault and updated function update_the_system

### DIFF
--- a/migrate_7.py
+++ b/migrate_7.py
@@ -242,18 +242,31 @@ def update_the_system():
     """
     if get_stage_status('update_the_system'):
         return
+
     try:
+        get_logger().info('Modifying YUM repository configuration')
+        # Modify the YUM repository configuration
+        subprocess.check_call(
+            "sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*",
+            shell=True,
+        )
+        subprocess.check_call(
+            "sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*",
+            shell=True,
+        )
+
         get_logger().info('Run updating of system')
         subprocess.check_call(
-            'yum update -y',
+            'sudo yum update -y',
             shell=True,
         )
     except subprocess.CalledProcessError:
         get_logger().error(
-            'Some error is occurred while updating system.'
+            'Some error occurred while updating the system.'
         )
         exit(1)
-    get_logger().info('Updating of system is completed successful')
+
+    get_logger().info('Updating of system is completed successfully')
     set_successful_stage_status('update_the_system')
 
 

--- a/migrate_7.py
+++ b/migrate_7.py
@@ -247,17 +247,17 @@ def update_the_system():
         get_logger().info('Modifying YUM repository configuration')
         # Modify the YUM repository configuration
         subprocess.check_call(
-            "sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*",
+            "sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*",
             shell=True,
         )
         subprocess.check_call(
-            "sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*",
+            "sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*",
             shell=True,
         )
 
         get_logger().info('Run updating of system')
         subprocess.check_call(
-            'sudo yum update -y',
+            'yum update -y',
             shell=True,
         )
     except subprocess.CalledProcessError:

--- a/migrate_7.py
+++ b/migrate_7.py
@@ -201,10 +201,10 @@ def install_centos_packages():
         return
     installed_pkgs = {
         'centos-release':
-            'http://mirror.centos.org/centos/7/os/x86_64/Packages'
+            'http://vault.centos.org/centos/7/os/x86_64/Packages'
             '/centos-release-7-9.2009.0.el7.centos.x86_64.rpm',
         'centos-logos':
-            'http://mirror.centos.org/centos/7/os/x86_64/Packages'
+            'http://vault.centos.org/centos/7/os/x86_64/Packages'
             '/centos-logos-70.0.6-3.el7.centos.noarch.rpm'
     }
     for installed_pkg_name, installed_pkg_url in installed_pkgs.iteritems():


### PR DESCRIPTION
Hello,

I have updated the script so it can continue working with vault url

updated url from mirror to vault

`    installed_pkgs = {
        'centos-release':
            'http://vault.centos.org/centos/7/os/x86_64/Packages'
            '/centos-release-7-9.2009.0.el7.centos.x86_64.rpm',
        'centos-logos':
            'http://vault.centos.org/centos/7/os/x86_64/Packages'
            '/centos-logos-70.0.6-3.el7.centos.noarch.rpm'
    }`


added update_the_system() to modify the yum repository with the vault url

`    try:
        get_logger().info('Modifying YUM repository configuration')
        # Modify the YUM repository configuration
        subprocess.check_call(
            "sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*",
            shell=True,
        )
        subprocess.check_call(
            "sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*",
            shell=True,
        )`